### PR TITLE
Update release note to bumped version

### DIFF
--- a/latest_release_note.md
+++ b/latest_release_note.md
@@ -1,4 +1,3 @@
-Release `0.1.0` introduces:
- * Automates the process for packaging a python library as a wheel via Poetry
- * CD workflow to build and create as release the bumped version of the packaged python library
- * Speeds up the update of an ETL pipeline by automating its build and release workflow
+Release `0.1.1` introduces:
+ * Update build python pkg pipeline to prevent existing releases to be replaced if developer forgets to bump version
+ * Add step to extract the last PR merge commit to be used as release title


### PR DESCRIPTION
PR to bump with patch fix but purposely forgotten to bump version on `pyproject` file.